### PR TITLE
feat: redirect pages.dev hostnames to soten.app

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,0 +1,10 @@
+export async function onRequest(context) {
+  const url = new URL(context.request.url);
+
+  if (url.hostname !== "preview.soten.pages.dev" && url.hostname.endsWith(".pages.dev")) {
+    url.hostname = "soten.app";
+    return Response.redirect(url.toString(), 301);
+  }
+
+  return context.next();
+}


### PR DESCRIPTION
Adds a Cloudflare Pages middleware function that issues a 301 redirect
to soten.app for any request arriving on a *.pages.dev hostname, while
leaving preview.soten.pages.dev unaffected.

Co-authored-by: Claude <noreply@anthropic.com>