### PR TITLE
fix(preview): add pull-requests: write permission to dispatch job

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       actions: write
       issues: write
+      pull-requests: write
 
     steps:
       - name: Get PR head SHA and dispatch deploy


### PR DESCRIPTION
The dispatch job calls github.rest.issues.addLabels on a pull request,
which requires pull-requests: write. Without it the step fails with
'Resource not accessible by integration', leaving the label unadded.

Discovered via run #12 failure on PR #100.