### PR TITLE
fix(preview): add pull-requests: write permission to deploy run job

### DIFF
--- a/.github/workflows/preview-deploy-run.yml
+++ b/.github/workflows/preview-deploy-run.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write
 
     steps:
       - name: React to trigger comment


### PR DESCRIPTION
The React to trigger comment step calls createForIssueComment to add
a rocket reaction. For PR comments, this requires pull-requests: write
even though the operation goes through the issues API. Without it the
step fails with Resource not accessible by integration, which prevents
the preview branch push and stalls the Cloudflare deployment.

This mirrors the same fix applied to preview-deploy.yml in #101.

Co-authored-by: Claude <noreply@anthropic.com>