### PR TITLE
feat: cache rendered markdown via Jotai atom family

### DIFF
--- a/plans/2026-03-03.cache-markdown-parsing.plan.md
+++ b/plans/2026-03-03.cache-markdown-parsing.plan.md
@@ -99,9 +99,9 @@ No longer `async`. No direct `renderMarkdown` call. The atom handles caching and
 
 ## What Changes
 
-| File | Change |
-|---|---|
-| `src/atoms/store.ts` | Add `renderedNoteAtom` (atom family, ~10 lines) |
-| `src/atoms/globals.ts` | Add `renderedNoteAtom` to re-export |
-| `src/routes/note.tsx` | Swap `renderMarkdown` call for `useAtom(renderedNoteAtom(path))`, remove `async` |
-| `src/markdown.ts` | No change |
+| File                   | Change                                                                           |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| `src/atoms/store.ts`   | Add `renderedNoteAtom` (atom family, ~10 lines)                                  |
+| `src/atoms/globals.ts` | Add `renderedNoteAtom` to re-export                                              |
+| `src/routes/note.tsx`  | Swap `renderMarkdown` call for `useAtom(renderedNoteAtom(path))`, remove `async` |
+| `src/markdown.ts`      | No change                                                                        |

--- a/src/atoms/globals.ts
+++ b/src/atoms/globals.ts
@@ -1,4 +1,4 @@
-export { store, machineAtom, filesAtom, noteListAtom } from "./store";
+export { store, machineAtom, filesAtom, noteListAtom, renderedNoteAtom } from "./store";
 export { send } from "./machine";
 
 import "./init.run";

--- a/src/atoms/store.ts
+++ b/src/atoms/store.ts
@@ -1,6 +1,6 @@
 import { createStore, atom } from "jotai";
-import { atomWithStorage } from "jotai/utils";
-import { extractTitle } from "../markdown";
+import { atomWithStorage, atomFamily } from "jotai/utils";
+import { extractTitle, renderMarkdown } from "../markdown";
 import { REPO_DIR } from "../lib/constants";
 import { t } from "../i18n";
 
@@ -113,6 +113,17 @@ function noteTitle(relativePath: string, content: string | null): string {
 
   return t("note.unnamedWithStem", { stem });
 }
+
+export type RenderedNote = { frontmatter: Record<string, unknown> | null; html: string };
+
+export const renderedNoteAtom = atomFamily((path: string) =>
+  atom(async (get) => {
+    const files = get(filesAtom);
+    const file = files[path];
+    if (!file || file.type !== "text") return null;
+    return renderMarkdown(file.content);
+  }),
+);
 
 export type NoteListEntry = { path: string; relativePath: string; title: string };
 

--- a/src/routes/note.tsx
+++ b/src/routes/note.tsx
@@ -1,8 +1,7 @@
 import { useAtom } from "jotai";
 import { Link, useParams } from "@tanstack/react-router";
 import { Suspense } from "react";
-import { renderMarkdown } from "../markdown";
-import { filesAtom } from "../atoms/globals";
+import { renderedNoteAtom } from "../atoms/globals";
 import { REPO_DIR } from "../lib/git";
 import { t } from "../i18n";
 
@@ -29,19 +28,14 @@ function Frontmatter({ data }: { data: Record<string, unknown> | null }) {
   );
 }
 
-async function Note({ path }: { path: string }) {
-  const [files] = useAtom(filesAtom);
-  const file = files[path];
+function Note({ path }: { path: string }) {
+  const [rendered] = useAtom(renderedNoteAtom(path));
+  if (!rendered) return null;
 
-  if (file.type !== "text") {
-    return null;
-  }
-
-  const md = await renderMarkdown(file.content);
   return (
     <>
-      <Frontmatter data={md.frontmatter} />
-      <div className="prose" dangerouslySetInnerHTML={{ __html: md.html }} />
+      <Frontmatter data={rendered.frontmatter} />
+      <div className="prose" dangerouslySetInnerHTML={{ __html: rendered.html }} />
     </>
   );
 }


### PR DESCRIPTION
## What

Replaced the direct renderMarkdown call in the Note component with a memoized Jotai atomFamily (renderedNoteAtom) that caches rendered HTML and frontmatter per file path.

## Why

The full unified markdown pipeline (6 plugins: parse → GFM → frontmatter → remark-rehype → rehype-raw → stringify) re-ran on every render of Note, even when the file content hadn’t changed. With the atom family, the pipeline runs once per file and the result is cached until filesAtom changes.

## Details

- renderedNoteAtom is an atomFamily keyed by file path. Each atom derives from filesAtom, checks that the file is text, and calls renderMarkdown. The async derived atom integrates with the existing <Suspense> boundary.
- Note is no longer async — it reads from the atom via useAtom and renders the cached result.
- extractTitle and the bulk noteListAtom derivation are unchanged; they’re already cheap (parse-only, no transforms) and run once per repo load.