### PR TITLE
refactor: convert repo switcher to /settings route

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,7 @@
+import { useEffect } from "react";
 import { useAtom } from "jotai";
-import { Outlet } from "@tanstack/react-router";
+import { Outlet, useNavigate } from "@tanstack/react-router";
 import { machineAtom, send } from "./atoms/globals";
-import { RepoSelector } from "./components/RepoSelector";
 import { UnauthenticatedView } from "./components/UnauthenticatedView";
 import { AuthenticatedShell } from "./components/AuthenticatedShell";
 import { AuthError } from "./components/AuthError";
@@ -18,6 +18,13 @@ function Shell({ children }: { children: ReactNode }) {
 
 export function App() {
   const [machine] = useAtom(machineAtom);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (machine.phase === "selectingRepo") {
+      navigate({ to: "/settings", replace: true });
+    }
+  }, [machine.phase, navigate]);
 
   if (machine.phase === "initializing") {
     return (
@@ -40,14 +47,13 @@ export function App() {
   return (
     <Shell>
       <AuthenticatedShell user={machine.user} selectedRepo={selectedRepo}>
-        {machine.phase === "selectingRepo" && <RepoSelector repos={machine.repos} />}
         {machine.phase === "error" && (
           <AuthError message={machine.message} onRetry={() => send({ type: "RETRY" })} />
         )}
         {(machine.phase === "fetchingRepos" ||
           machine.phase === "cloningRepo" ||
           machine.phase === "loadingFiles") && <div>{t("app.initializing")}</div>}
-        {machine.phase === "ready" && <Outlet />}
+        {(machine.phase === "ready" || machine.phase === "selectingRepo") && <Outlet />}
       </AuthenticatedShell>
     </Shell>
   );

--- a/src/atoms/machine.test.ts
+++ b/src/atoms/machine.test.ts
@@ -181,26 +181,6 @@ describe("SELECT_REPO", () => {
   });
 });
 
-describe("SWITCH_REPO", () => {
-  it("goes to selectingRepo from ready", async () => {
-    store.set(machineAtom, {
-      phase: "ready",
-      user: mockUser,
-      repos: ["acme/notes", "acme/wiki"],
-      selectedRepo: { owner: "acme", repo: "notes" },
-      filenames: [],
-      files: {},
-    });
-
-    await send({ type: "SWITCH_REPO" });
-
-    const m = machine();
-    expect(m.phase).toBe("selectingRepo");
-    if (m.phase !== "selectingRepo") return;
-    expect(m.repos).toEqual(["acme/notes", "acme/wiki"]);
-  });
-});
-
 describe("RETRY", () => {
   it("re-enters authenticate flow from error", async () => {
     store.set(machineAtom, { phase: "error", message: "Failed", user: mockUser });

--- a/src/atoms/machine.ts
+++ b/src/atoms/machine.ts
@@ -9,7 +9,6 @@ export type Transition =
   | { type: "AUTHENTICATE"; user: User }
   | { type: "LOGOUT" }
   | { type: "SELECT_REPO"; owner: string; repo: string }
-  | { type: "SWITCH_REPO" }
   | { type: "RETRY" };
 
 class AbortError extends Error {}
@@ -37,9 +36,6 @@ export async function send(transition: Transition): Promise<void> {
         break;
       case "SELECT_REPO":
         await selectRepo(transition.owner, transition.repo, checkAborted);
-        break;
-      case "SWITCH_REPO":
-        switchRepo();
         break;
       case "RETRY":
         await retry(checkAborted);
@@ -104,13 +100,6 @@ async function selectRepo(owner: string, repo: string, checkAborted: () => void)
   store.set(selectedRepoAtom, selectedRepo);
   wipeFs();
   await cloneAndLoad(machine.user, machine.repos, selectedRepo, checkAborted);
-}
-
-function switchRepo(): void {
-  const machine = store.get(machineAtom);
-  if (machine.phase !== "ready") return;
-
-  store.set(machineAtom, { phase: "selectingRepo", user: machine.user, repos: machine.repos });
 }
 
 async function retry(checkAborted: () => void): Promise<void> {

--- a/src/components/AuthenticatedShell.tsx
+++ b/src/components/AuthenticatedShell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { send } from "../atoms/globals";
 import { t } from "../i18n";
 import type { User, Repo } from "../atoms/store";
@@ -26,9 +26,9 @@ export function AuthenticatedShell({
           {selectedRepo && (
             <p className="text-sm">
               {selectedRepo.owner}/{selectedRepo.repo}{" "}
-              <Button variant="link" onClick={() => send({ type: "SWITCH_REPO" })}>
+              <Link to="/settings" className="underline">
                 {t("auth.switchRepo")}
-              </Button>
+              </Link>
             </p>
           )}
           <p>

--- a/src/components/RepoSelector.tsx
+++ b/src/components/RepoSelector.tsx
@@ -2,7 +2,13 @@ import { send } from "../atoms/globals";
 import { t } from "../i18n";
 import { Button } from "./Button";
 
-export function RepoSelector({ repos }: { repos: string[] }) {
+export function RepoSelector({
+  repos,
+  onSelect,
+}: {
+  repos: string[];
+  onSelect?: (owner: string, repo: string) => void;
+}) {
   return (
     <div className="my-4">
       <p className="mb-2 font-semibold">{t("repo.selectRepository")}</p>
@@ -13,7 +19,9 @@ export function RepoSelector({ repos }: { repos: string[] }) {
             <li key={fullName} className="my-1">
               <Button
                 className="px-3 py-1 font-mono text-sm"
-                onClick={() => send({ type: "SELECT_REPO", owner, repo })}
+                onClick={() =>
+                  onSelect ? onSelect(owner, repo) : send({ type: "SELECT_REPO", owner, repo })
+                }
               >
                 {fullName}
               </Button>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -2,6 +2,7 @@ import { createRouter, createRoute, createRootRoute } from "@tanstack/react-rout
 import { App } from "./app.tsx";
 import { FrontPage } from "./routes/front.tsx";
 import { NotePage } from "./routes/note.tsx";
+import { SettingsPage } from "./routes/settings.tsx";
 
 const rootRoute = createRootRoute({
   component: App,
@@ -24,7 +25,17 @@ const noteViewRoute = createRoute({
   component: NotePage,
 });
 
-const routeTree = rootRoute.addChildren([indexRoute, noteRoute.addChildren([noteViewRoute])]);
+const settingsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "settings",
+  component: SettingsPage,
+});
+
+const routeTree = rootRoute.addChildren([
+  indexRoute,
+  noteRoute.addChildren([noteViewRoute]),
+  settingsRoute,
+]);
 
 export const router = createRouter({ routeTree });
 

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1,0 +1,22 @@
+import { useAtom } from "jotai";
+import { useNavigate } from "@tanstack/react-router";
+import { machineAtom, send } from "../atoms/globals";
+import { RepoSelector } from "../components/RepoSelector";
+
+export function SettingsPage() {
+  const [machine] = useAtom(machineAtom);
+  const navigate = useNavigate();
+
+  const repos = "repos" in machine ? machine.repos : null;
+  if (!repos) return null;
+
+  return (
+    <RepoSelector
+      repos={repos}
+      onSelect={(owner, repo) => {
+        navigate({ to: "/", replace: true });
+        send({ type: "SELECT_REPO", owner, repo });
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## What

Converted the repo switcher from an in-memory app state (`SWITCH_REPO` machine transition) to a proper `/settings` URL route using TanStack Router. Both the onboarding flow and the "switch repo" action now navigate to `/settings`.

## Why

The repo switcher was the only interactive screen rendered purely via app state with no corresponding URL. This made it invisible to the browser's navigation (no back button, no bookmarkable URL) and left no natural place to add future settings. A dedicated `/settings` route fixes both issues.

## Details

- Added `/settings` route (`src/routes/settings.tsx`) that renders `RepoSelector` with navigation-aware selection
- `app.tsx` renders `<Outlet />` for `selectingRepo` phase (in addition to `ready`) and auto-navigates to `/settings` via `useEffect`
- `RepoSelector` gained an optional `onSelect` prop so the settings page can navigate before dispatching
- "Switch repo" link in `AuthenticatedShell` is now a `<Link to="/settings">` instead of a machine dispatch
- Removed the `SWITCH_REPO` transition, `switchRepo()` function, and its test